### PR TITLE
User browser local time to determine challenge day

### DIFF
--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -8,7 +8,7 @@ import {
 import { settings$ } from './components/settings/store';
 import { addGameToStats } from './components/stats/store';
 import { createLocalStorageStore } from './storage';
-import type { Country, Game } from './types';
+import type { Challenge, Country, Game } from './types';
 
 export const MAX_GUESSES = 6;
 
@@ -16,7 +16,8 @@ export class Game$ implements Readable<Game> {
 	private store$: Writable<Game>;
 	private timeout?: NodeJS.Timeout;
 
-	constructor(isoDate: string, countryList: Country[], answer: Country, borders: string[]) {
+	constructor(isoDate: string, countryList: Country[], challenge: Challenge) {
+		const { borders, ...answer } = challenge;
 		this.store$ = createLocalStorageStore<Game>(`${isoDate}-game`, () => ({
 			isoDate,
 			countryList,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,10 @@ export interface Country {
 	code: string;
 }
 
+export interface Challenge extends Country {
+	borders: string[];
+}
+
 export interface Guess extends Country {
 	correct: boolean;
 	close: boolean;

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
 	import CountrySearch from '$lib/components/CountrySearch.svelte';
 	import Guesses from '$lib/components/Guesses.svelte';
+	import Header from '$lib/components/Header.svelte';
 	import Map from '$lib/components/map/Map.svelte';
-	import { addGameToStats } from '$lib/components/stats/store';
 	import { Game$ } from '$lib/game';
-	import type { Country, Game } from '$lib/types';
-	import Header from '../lib/components/Header.svelte';
+	import type { Challenge, Country } from '$lib/types';
+	import { toIsoDate } from '$lib/utils';
 
 	//@hmr:keep-all
-	export let isoDate: string;
 	export let countryList: Country[];
-	export let answer: Country;
-	export let borders: string[];
+	export let challenges: Partial<Record<string, Challenge>>;
 
-	const game$ = new Game$(isoDate, countryList, answer, borders);
+	const isoDate = toIsoDate(new Date());
+	const challenge = challenges[isoDate];
+	const game$ = challenge && new Game$(isoDate, countryList, challenge);
 
 	let keyboardOpen = false;
 	globalThis.visualViewport?.addEventListener('resize', () => {
-		keyboardOpen = globalThis.visualViewport.height < globalThis.screen.height * 0.7;
+		setTimeout(
+			() => (keyboardOpen = globalThis.visualViewport.height < globalThis.screen.height * 0.7),
+			50,
+		);
 	});
 </script>
 
@@ -25,17 +28,33 @@
 	<title>Worldie</title>
 </svelte:head>
 
-<main class="bg-blue-100 inset-0 fixed flex flex-col items-center">
-	<header class="fixed top-0 w-full z-[999] bg-white">
-		<Header {game$} />
-	</header>
+<main class="bg-blue-100 inset-0 fixed flex flex-col items-center justify-center">
+	{#if game$}
+		<header class="fixed top-0 w-full z-[999] bg-white">
+			<Header {game$} />
+		</header>
 
-	<Map {game$} />
+		<Map {game$} />
 
-	<footer class="fixed bottom-0 w-full z-[999] flex justify-center items-center portrait:flex-col">
-		<CountrySearch {game$} />
-		{#if !keyboardOpen}
-			<Guesses {game$} />
-		{/if}
-	</footer>
+		<footer
+			class="fixed bottom-0 w-full z-[999] flex justify-center items-center portrait:flex-col"
+		>
+			<CountrySearch {game$} />
+			{#if !keyboardOpen}
+				<Guesses {game$} />
+			{/if}
+		</footer>
+	{:else}
+		<p class="m-3 text-center">
+			Mate, are you from the future or something? Your clock is set for a day I don't have a
+			challenge for.
+		</p>
+		<p class="m-3 text-center">Please fix your clock and/or refresh the page.</p>
+		<p class="m-3 text-center">
+			If the issue persists please create an issue on GitHub:
+			<a class="underline" href="https://github.com/miridius/worldie/issues"
+				>https://github.com/miridius/worldie/issues</a
+			>
+		</p>
+	{/if}
 </main>


### PR DESCRIPTION
The user's clock will now be used to reset the challenge at their midnight instead of based on UTC.

New challenges are technically available from the server at UTC+12, which should cover all time zones I hope...

Fixes #38